### PR TITLE
Remove links to announcements, mentoring and CTF

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,9 +81,6 @@
                 <h1>Are you ready for <br/><span class="header-title"><span>Hack</span><span>The</span><span>Midlands 4.0? </span></span></h1>
                 <h3>26<sup>th</sup> - 27<sup>th</sup> October, Millennium Point, Birmingham</h3>
                 <a href="/event-info.html"><button id="apply-button">Event Information</button></a>
-                <a href="https://info.hackthemidlands.com"><button id="apply-button">Announcements</button></a>
-                <a href="https://help.hackthemidlands.com"><button id="apply-button">Get Help</button></a>
-                <a href="https://ctf.hackthemidlands.com"><button id="apply-button">Capture The Flag</button></a>
                 <a href="sponsorship.pdf"><button id="apply-button">Sponsor Us</button></a>
 
                 <a href="https://www.youtube.com/watch?v=bakpTO7weKk"><h3 style="font-size: 15px; padding-top: 10px; font-weight: 500">Watch The Video!</h3></a>


### PR DESCRIPTION
These all point to sites that have been taken down after the event.